### PR TITLE
add parallel support for kill unused segments

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -74,7 +74,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     );
 
     final KillUnusedSegmentsTask task =
-        new KillUnusedSegmentsTask(null, DATA_SOURCE, Intervals.of("2019-03-01/2019-04-01"), null);
+        new KillUnusedSegmentsTask(null, DATA_SOURCE, Intervals.of("2019-03-01/2019-04-01"), null, null);
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -390,6 +390,7 @@ public class TaskSerdeTest
         null,
         "foo",
         Intervals.of("2010-01-01/P1D"),
+        null,
         null
     );
 
@@ -405,6 +406,7 @@ public class TaskSerdeTest
     Assert.assertEquals(task.getGroupId(), task2.getGroupId());
     Assert.assertEquals(task.getDataSource(), task2.getDataSource());
     Assert.assertEquals(task.getInterval(), task2.getInterval());
+    Assert.assertEquals(task.getNumThreads().longValue(), 1l);
 
     final KillUnusedSegmentsTask task3 = (KillUnusedSegmentsTask) jsonMapper.readValue(
         jsonMapper.writeValueAsString(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -922,7 +922,7 @@ public class TaskLifecycleTest
     }
 
     final Task killUnusedSegmentsTask =
-        new KillUnusedSegmentsTask(null, "test_kill_task", Intervals.of("2011-04-01/P4D"), null);
+        new KillUnusedSegmentsTask(null, "test_kill_task", Intervals.of("2011-04-01/P4D"), null, null);
 
     final TaskStatus status = runTask(killUnusedSegmentsTask);
     Assert.assertEquals(taskLocation, status.getLocation());

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
@@ -32,15 +32,26 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
 {
   private final String dataSource;
   private final Interval interval;
+  private final Integer numThreads;
 
+  
+  @JsonCreator
+  public ClientKillUnusedSegmentsTaskQuery(@JsonProperty("dataSource") String dataSource,
+      @JsonProperty("interval") Interval interval)
+  {
+    this(dataSource, interval, null);
+  }
+  
   @JsonCreator
   public ClientKillUnusedSegmentsTaskQuery(
       @JsonProperty("dataSource") String dataSource,
-      @JsonProperty("interval") Interval interval
+      @JsonProperty("interval") Interval interval,
+      @JsonProperty("numThreads") Integer numThreads
   )
   {
     this.dataSource = dataSource;
     this.interval = interval;
+    this.numThreads = numThreads;
   }
 
   @JsonProperty
@@ -50,6 +61,12 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
     return "kill";
   }
 
+  @JsonProperty
+  public Integer getNumThreads()
+  {
+    return numThreads;
+  }
+  
   @JsonProperty
   @Override
   public String getDataSource()

--- a/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
@@ -65,9 +65,9 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
   }
 
   @Override
-  public void killUnusedSegments(String dataSource, Interval interval)
+  public void killUnusedSegments(String dataSource, Interval interval, Integer numThreads)
   {
-    runTask(new ClientKillUnusedSegmentsTaskQuery(dataSource, interval));
+    runTask(new ClientKillUnusedSegmentsTaskQuery(dataSource, interval, numThreads));
   }
 
   @Override
@@ -108,7 +108,7 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
       final StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(HttpMethod.POST, "/druid/indexer/v1/task")
                            .setContent(MediaType.APPLICATION_JSON, jsonMapper.writeValueAsBytes(taskObject))
-      );
+        );
 
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {
         if (!Strings.isNullOrEmpty(response.getContent())) {

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -31,8 +31,15 @@ import java.util.Set;
 
 public interface IndexingServiceClient
 {
-  void killUnusedSegments(String dataSource, Interval interval);
 
+  void killUnusedSegments(String dataSource, Interval interval, Integer numThreads);
+
+  default void killUnusedSegments(String dataSource, Interval interval)
+  {
+    killUnusedSegments(dataSource, interval, null);
+  }
+
+  
   int killPendingSegments(String dataSource, DateTime end);
 
   String compactSegments(

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -297,7 +297,8 @@ public class DataSourcesResource
   public Response markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval(
       @PathParam("dataSourceName") final String dataSourceName,
       @QueryParam("kill") final String kill,
-      @QueryParam("interval") final String interval
+      @QueryParam("interval") final String interval,
+      @QueryParam("numThreads") final Integer numThreads
   )
   {
     if (indexingServiceClient == null) {
@@ -306,7 +307,7 @@ public class DataSourcesResource
 
     boolean killSegments = kill != null && Boolean.valueOf(kill);
     if (killSegments) {
-      return killUnusedSegmentsInInterval(dataSourceName, interval);
+      return killUnusedSegmentsInInterval(dataSourceName, interval, numThreads);
     } else {
       MarkSegments markSegments = () -> segmentsMetadataManager.markAsUnusedAllSegmentsInDataSource(dataSourceName);
       return doMarkSegments("markAsUnusedAllSegments", dataSourceName, markSegments);
@@ -319,7 +320,8 @@ public class DataSourcesResource
   @Produces(MediaType.APPLICATION_JSON)
   public Response killUnusedSegmentsInInterval(
       @PathParam("dataSourceName") final String dataSourceName,
-      @PathParam("interval") final String interval
+      @PathParam("interval") final String interval,
+      @QueryParam("numThreads") final Integer numThreads
   )
   {
     if (indexingServiceClient == null) {
@@ -330,7 +332,7 @@ public class DataSourcesResource
     }
     final Interval theInterval = Intervals.of(interval.replace('_', '/'));
     try {
-      indexingServiceClient.killUnusedSegments(dataSourceName, theInterval);
+      indexingServiceClient.killUnusedSegments(dataSourceName, theInterval, numThreads);
       return Response.ok().build();
     }
     catch (Exception e) {

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
@@ -33,7 +33,7 @@ import java.util.Set;
 public class NoopIndexingServiceClient implements IndexingServiceClient
 {
   @Override
-  public void killUnusedSegments(String dataSource, Interval interval)
+  public void killUnusedSegments(String dataSource, Interval interval, Integer numThreads)
   {
 
   }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -592,13 +592,13 @@ public class DataSourcesResourceTest
     Interval theInterval = Intervals.of(interval.replace('_', '/'));
 
     IndexingServiceClient indexingServiceClient = EasyMock.createStrictMock(IndexingServiceClient.class);
-    indexingServiceClient.killUnusedSegments("datasource1", theInterval);
+    indexingServiceClient.killUnusedSegments("datasource1", theInterval, null);
     EasyMock.expectLastCall().once();
     EasyMock.replay(indexingServiceClient, server);
 
     DataSourcesResource dataSourcesResource =
         new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null, null);
-    Response response = dataSourcesResource.killUnusedSegmentsInInterval("datasource1", interval);
+    Response response = dataSourcesResource.killUnusedSegmentsInInterval("datasource1", interval, null);
 
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(null, response.getEntity());
@@ -614,7 +614,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null, null);
     try {
       Response response =
-          dataSourcesResource.markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", "true", "???");
+          dataSourcesResource.markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", "true", "???", null);
       // 400 (Bad Request) or an IllegalArgumentException is expected.
       Assert.assertEquals(400, response.getStatus());
       Assert.assertNotNull(response.getEntity());


### PR DESCRIPTION
In a cluster with a large number of data sources, it is convenient to reuse retention rules between different data sources. The default rules on a cluster must apply to every data source in the cluster, so this is not sufficiently fine grained. It would be useful to provide a flexible mechanism to share rules between datasources.  A new import rule could dynamically import rules from the other data source every time rules are applied. This can be implemented using the existing API with the addition of a new rule type that specifies an imported ruleset, as shown here. 

![sizecheck](https://user-images.githubusercontent.com/8482587/86393561-3ed6ab80-bc6b-11ea-8521-663126be0475.gif)

### Description

This branch adds a new ImportRule type that specifies an imported rule set. Whenever rules are used, they are expanded to include the default rules for the cluster. This changes the getRulesWithDefault to also expand any import rules found at the time they are retrieved. This is functionally equivalent to the original list as the rules are replaced before evaluation. Rules are also used in CoordinatorRuleManager in the router, where getRulesWithDefault was implemented again. Here, that implementation is left at one place, in SQLRuleManager and a new method is added to RulesResource to allow CoordinatorRuleManager to retrieve the expanded list of rules without knowing how it was generated. 

### Alternatives


Flexible Defaults

Allow for multiple default rule lists, instead of just one. Because of the prevalent assumption of ForeverLoad being the default rule, it would be complicated to remove that assumption everywhere. So, a second tier of defaults would be needed. 

Clone Rules - Rules from other data sources could be copied using existing APIs, but changes to the copied rules would not reflect. This is a problem for maintenance as the user will still need to review every data source on changes. 

	Evaluation Import Rules - Alternative to modifying the rules list when expanded, it would be possible to do the import at rule evaluation time. This requires evaluating imports and breaking cycles for each segment as well as introducing more complex test cases regarding concurrent changes to retention rules. 

       In the implementation, the function of getRulesWithDefault has diverged a little bit from the name, maybe a name like getExpandedRules would be better. Also, the implementation for ImportRule is specifically in SQLMetadataRuleManager maybe it should be interface methods or in a utility class for use by other implementations in the future. 

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `SQLMetadataRuleManager`
 * `ImportRule`
 * `CoordinatorRuleManager`
 * `RulesResource`
